### PR TITLE
Add OpenCost UI note

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -34,7 +34,7 @@ helm install my-prometheus --repo https://prometheus-community.github.io/helm-ch
 
 This Prometheus installation is based on Prom community helm chart, and by default your Prometheus might scrape unnecessary metrics. For production, you can refer to the Kubecost [user metrics list](https://guide.kubecost.com/hc/en-us/articles/4425134686743-User-Metrics) to filter with 'keep', for reference take a look at scrape config in the Kubecost installation [chart](https://github.com/kubecost/cost-analyzer-helm-chart/blob/v1.98/cost-analyzer/charts/prometheus/values.yaml#L1208).
 
-If you are going to conect existing Prometheus instance which is already consuming KSM metrics, please consider visiting this page about [KSM metrics emission](https://guide.kubecost.com/hc/en-us/articles/4408095797911), because Opencost currently implements the same architecture and you might get overlapping metrics.
+If you are going to connect existing Prometheus instance which is already consuming KSM metrics, please consider visiting this page about [KSM metrics emission](https://guide.kubecost.com/hc/en-us/articles/4408095797911), because Opencost currently implements the same architecture and you might get overlapping metrics.
 
 ## Installing OpenCost
 
@@ -51,12 +51,14 @@ kubectl apply --namespace opencost -f https://raw.githubusercontent.com/opencost
 Wait for the pod to be ready and then port forward with:
 
 ```sh
-kubectl port-forward --namespace opencost service/opencost 9003
+kubectl port-forward --namespace opencost service/opencost 9003 9090
 ```
 
 ## Testing
 
 To test that the server is running, you can hit [http://localhost:9003/allocation/compute?window=60m](http://localhost:9003/allocation/compute?window=60m)
+
+You can also access the OpenCost UI at [http://localhost:9090](http://localhost:9090)
 
 See more [API Examples](./api.md).
 


### PR DESCRIPTION
This PR introduces a note in the install instructions on how to access the OpenCost UI. 

Can only be merged **after** ~~https://github.com/opencost/opencost/pull/1527~~ https://github.com/opencost/opencost/pull/1557