### PR TITLE
References #75 - set explicit logo for dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,6 +81,7 @@ const config = {
         logo: {
           alt: "OpenCost Logo",
           src: "img/logo.png",
+          srcDark: "img/logo-white.png",
         },
         items: [
           { to: "/enterprise", label: "Enterprise", position: "left" },


### PR DESCRIPTION
Fixes: https://github.com/opencost/opencost-website/issues/75