### PR TITLE
fix(blog): Add canonical references to anchor tags

### DIFF
--- a/blog/2023-02-02-grafana-labs/index.mdx
+++ b/blog/2023-02-02-grafana-labs/index.mdx
@@ -4,7 +4,10 @@ title: "Repost: How Grafana Labs uses and contributes to OpenCost"
 authors: [mattray]
 tags: [opencost, grafana]
 ---
-Reposted from the [Grafana Labs blog](https://grafana.com/blog/): <a rel="canonical" href="https://grafana.com/blog/2023/02/02/how-grafana-labs-uses-and-contributes-to-opencost-the-open-source-project-for-real-time-cost-monitoring-in-kubernetes/">How Grafana Labs uses and contributes to OpenCost</a>
+<head>
+    <link rel="canonical" href="https://grafana.com/blog/2023/02/02/how-grafana-labs-uses-and-contributes-to-opencost-the-open-source-project-for-real-time-cost-monitoring-in-kubernetes/"/>
+</head>
+Reposted from the [Grafana Labs blog](https://grafana.com/blog/): [How Grafana Labs uses and contributes to OpenCost](https://grafana.com/blog/2023/02/02/how-grafana-labs-uses-and-contributes-to-opencost-the-open-source-project-for-real-time-cost-monitoring-in-kubernetes/)
 
 ![Grafana Labs + OpenCost](./img/image3.png)
 

--- a/blog/2023-02-02-grafana-labs/index.mdx
+++ b/blog/2023-02-02-grafana-labs/index.mdx
@@ -4,7 +4,7 @@ title: "Repost: How Grafana Labs uses and contributes to OpenCost"
 authors: [mattray]
 tags: [opencost, grafana]
 ---
-Reposted from the [Grafana Labs blog](https://grafana.com/blog/): [How Grafana Labs uses and contributes to OpenCost](https://grafana.com/blog/2023/02/02/how-grafana-labs-uses-and-contributes-to-opencost-the-open-source-project-for-real-time-cost-monitoring-in-kubernetes/)
+Reposted from the [Grafana Labs blog](https://grafana.com/blog/): <a rel="canonical" href="https://grafana.com/blog/2023/02/02/how-grafana-labs-uses-and-contributes-to-opencost-the-open-source-project-for-real-time-cost-monitoring-in-kubernetes/">How Grafana Labs uses and contributes to OpenCost</a>
 
 ![Grafana Labs + OpenCost](./img/image3.png)
 

--- a/blog/2023-06-27-grafana-cloud/index.mdx
+++ b/blog/2023-06-27-grafana-cloud/index.mdx
@@ -4,7 +4,7 @@ title: "Repost: Rein in spending with Kubernetes cost monitoring in Grafana Clou
 authors: [mattray]
 tags: [opencost, grafana]
 ---
-Reposted from the [Grafana Labs blog](https://grafana.com/blog/): [Rein in spending with Kubernetes cost monitoring in Grafana Cloud](https://grafana.com/blog/2023/06/26/rein-in-spending-with-kubernetes-cost-monitoring-in-grafana-cloud/)
+Reposted from the [Grafana Labs blog](https://grafana.com/blog/): <a rel="canonical" href="https://grafana.com/blog/2023/06/26/rein-in-spending-with-kubernetes-cost-monitoring-in-grafana-cloud/"> Rein in spending with Kubernetes cost monitoring in Grafana Cloud</a>
 
 Original authors: [Vasil Kaftandzhiev](https://grafana.com/author/vasil-kaftandzhiev/), [Jake Swiss](https://grafana.com/author/jake_swiss/)
 

--- a/blog/2023-06-27-grafana-cloud/index.mdx
+++ b/blog/2023-06-27-grafana-cloud/index.mdx
@@ -4,7 +4,11 @@ title: "Repost: Rein in spending with Kubernetes cost monitoring in Grafana Clou
 authors: [mattray]
 tags: [opencost, grafana]
 ---
-Reposted from the [Grafana Labs blog](https://grafana.com/blog/): <a rel="canonical" href="https://grafana.com/blog/2023/06/26/rein-in-spending-with-kubernetes-cost-monitoring-in-grafana-cloud/"> Rein in spending with Kubernetes cost monitoring in Grafana Cloud</a>
+<head>
+    <link rel="canonical" href="https://grafana.com/blog/2023/06/26/rein-in-spending-with-kubernetes-cost-monitoring-in-grafana-cloud/" />
+</head>
+
+Reposted from the [Grafana Labs blog](https://grafana.com/blog/): [Rein in spending with Kubernetes cost monitoring in Grafana Cloud](https://grafana.com/blog/2023/06/26/rein-in-spending-with-kubernetes-cost-monitoring-in-grafana-cloud/)
 
 Original authors: [Vasil Kaftandzhiev](https://grafana.com/author/vasil-kaftandzhiev/), [Jake Swiss](https://grafana.com/author/jake_swiss/)
 


### PR DESCRIPTION
Marketing folks within Grafana Labs requested that we add rel="canonical" to help with SEO for the reposted blog posts.

This change should preserve the previous styling while adding `rel="canonical"` to both blog post links.