### PR TITLE
Point out location of cloud cost-enabled builds

### DIFF
--- a/docs/configuration/aws.md
+++ b/docs/configuration/aws.md
@@ -76,7 +76,7 @@ serviceAccount:
 
 :::info
 
-The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` to access this beta feature.
 
 :::
 

--- a/docs/configuration/aws.md
+++ b/docs/configuration/aws.md
@@ -74,6 +74,12 @@ serviceAccount:
 
 ## AWS Cloud Cost Configuration
 
+:::info
+
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+
+:::
+
 To configure OpenCost for your AWS account, create an Access Key for the OpenCost user who has access to the Cost and Usage Report (CUR). Navigate to the [IAM Management Console dashboard](https://console.aws.amazon.com/iam), and select *Access Management > Users*. Find the OpenCost user and select *Security Credentials > Create Access Key*. Note the Access Key ID and Secret access key.
 
 * `<ACCESS_KEY_ID>` is the ID of the Access Key created in the previous step.

--- a/docs/configuration/azure.md
+++ b/docs/configuration/azure.md
@@ -266,7 +266,7 @@ echo "Response: ${RESPONSE}"
 
 :::info
 
-The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` to access this beta feature.
 
 :::
 

--- a/docs/configuration/azure.md
+++ b/docs/configuration/azure.md
@@ -264,6 +264,12 @@ echo "Response: ${RESPONSE}"
 
 ## Azure Cloud Cost Configuration
 
+:::info
+
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+
+:::
+
 The following values can be found in the Azure Portal under *Cost Management > Exports*, or *Storage* accounts:
 
 * `<SUBSCRIPTION_ID>` is the Subscription ID belonging to the Storage account which stores your exported Azure cost report data.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -12,6 +12,12 @@ Kubernetes cloud cost allocation utilizes on-demand APIs for pricing data, but a
 
 ## Cloud Costs
 
+:::info
+
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+
+:::
+
 To access general cloud costs you will need to set up cost data exports for your cloud provider. Your account details and credentials will be kept in a secret file named `cloud-integration.json` with the following format only containing applicable CSPs for your installation:
 ```
 {

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -14,7 +14,7 @@ Kubernetes cloud cost allocation utilizes on-demand APIs for pricing data, but a
 
 :::info
 
-The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` to access this beta feature.
 
 :::
 

--- a/docs/configuration/gcp.md
+++ b/docs/configuration/gcp.md
@@ -19,7 +19,7 @@ To enable OpenCost to fetch pricing information from your GCP project, you must 
 
 :::info
 
-The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` to access this beta feature.
 
 :::
 

--- a/docs/configuration/gcp.md
+++ b/docs/configuration/gcp.md
@@ -17,6 +17,12 @@ To enable OpenCost to fetch pricing information from your GCP project, you must 
 
 ## GCP Cloud Cost Configuration
 
+:::info
+
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+
+:::
+
 To configure OpenCost for your GCP account, create a GCP service key with the following commands in your command line to generate and export one. Make sure your GCP project is where your external costs are being run.
 
 ``` sh

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -35,7 +35,7 @@ If you want more accurate results or Cloud Costs from your provider's bill pleas
 
 :::info
 
-The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` to access this beta feature.
 
 :::
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -33,6 +33,12 @@ That is all that is required for most initial installations.
 
 If you want more accurate results or Cloud Costs from your provider's bill please refer to the [Cloud Service Provider Configuration](../configuration/) page. You will need to manage your deployment with the [Helm](helm) chart to configure this.
 
+:::info
+
+The Cloud Costs feature is not in the current stable release yet. Please use the OpenCost image `gcr.io/kubecost1/opencost:cloudcost` and the OpenCost UI image `gcr.io/kubecost1/opencost-ui:cloudcost` in the meantime.
+
+:::
+
 ## Testing
 
 Once your OpenCost has been installed, wait for the pod to be ready and port forward with:


### PR DESCRIPTION
We'll remove update these once they're in the current stable release, then remove completely in 2 releases.