### PR TITLE
Add instructions how to overwrite pricing configuration of cloud providers

### DIFF
--- a/docs/configuration/on-prem.md
+++ b/docs/configuration/on-prem.md
@@ -124,6 +124,18 @@ opencost:
     createConfigmap: false
 ```
 
+You can us this to overwrite pricings for your cloud provider in case you want to consider custom pricing agreements and/or benefits like reserved instances or licensing cost. In case you decide to to this make sure to provide the "correct" `configmapName` since OpenCost relies on distinct names for pricing configuration.
+
+| Provider | Filename |
+|----------|----------|
+| Azure | azure.json |
+| AWS    | aws.json |
+| GCP    | gcp.json |
+| Scaleway | scaleway.json |
+| Alibaba | alibaba.json |
+| Oracle | oracle.json |
+
+
 ### Method 2
 
 Provide your custom pricing via helm overrides during install.

--- a/docs/configuration/on-prem.md
+++ b/docs/configuration/on-prem.md
@@ -133,8 +133,6 @@ You can us this to overwrite pricings for your cloud provider in case you want t
 | GCP    | gcp.json |
 | Scaleway | scaleway.json |
 | Alibaba | alibaba.json |
-| Oracle | oracle.json |
-
 
 ### Method 2
 


### PR DESCRIPTION
As discussed [here](https://cloud-native.slack.com/archives/C03D56FPD4G/p1706738637001029?thread_ts=1704722058.197489&cid=C03D56FPD4G) I've added instructions on how to overwrite pricing configurations for cloud providers since it is not immediately clear that the configmaps holding the information must follow certain naming conventions.