### PR TITLE
Add new "Running in Docker" section

### DIFF
--- a/docs/installation/development.md
+++ b/docs/installation/development.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Setting up a Development Environment
@@ -35,4 +35,4 @@ Tilt is a great way to run OpenCost on a local or remote Kubernetes environment.
 ## Attach Debugger to the Back End
 The OpenCost back end auto starts with delve by default. Configure your IDE or text editor to attach to `http://localhost:40000`.
 
-If you want to attach the debugger at startup, remove the `--continue` flag from the entrypoint in the `docker_build_with_restart` function in the `Tiltfile`, then connect the debugger. Once connected, the OpenCost back end will start. 
+If you want to attach the debugger at startup, remove the `--continue` flag from the entrypoint in the `docker_build_with_restart` function in the `Tiltfile`, then connect the debugger. Once connected, the OpenCost back end will start.

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 5
+---
+# Running in Docker
+
+:::info
+
+Support for running within Docker is included in the stable releases as of 1.109.0. Please ensure you have the latest release to access this new feature.
+
+:::
+
+Running OpenCost outside of Kubernetes will give you access to your [Cloud Costs](https://www.opencost.io/docs/configuration/#cloud-costs) via the [API](https://www.opencost.io/docs/integrations/api#cloud-costs-api) and UI, but you will not have Kubernetes Cost Allocation data available.
+
+## Running OpenCost without Kubernetes
+
+Given that not everyone who wants to look at their cloud billing is using Kubernetes, to run without Kubernetes you can either run from Docker or directly from the CLI. There are 2 environment variables you will need to set:
+* `CLOUD_COST_ENABLED=true` (default is `false` since it's beta)
+* `CLOUD_COST_CONFIG_PATH=/path/to/file` - you will need to [provide your credentials](https://www.opencost.io/docs/configuration/) in a file (default is `cloud-integration.json`). [Here’s an example file](https://gist.github.com/mattray/090a43aa4e64f8fc78572cd8d504a4b7).
+
+### Running with Docker
+
+If you want to run with Docker, you can pull down the image from [ghcr.io/opencost/opencost:1.109.0](https://github.com/opencost/opencost/pkgs/container/opencost):
+
+`docker pull ghcr.io/opencost/opencost:1.109.0` (or `latest`)
+
+and run it with
+
+`docker run -e CLOUD_COST_ENABLED=true -e CLOUD_COST_CONFIG_PATH=/tmp/cloud-integration.json -p 9003:9003 -d -v /tmp:/tmp ghcr.io/opencost/opencost:1.109.0`
+
+#### Accessing the Cloud Costs API
+
+The OpenCost [Cloud Cost API](https://www.opencost.io/docs/integrations/api#cloudcost) is now exposed on port 9003, you can test with
+
+`curl -G http://localhost:9003/cloudCost -d window=7d -d aggregate=provider | jq`
+
+The [Cloud Cost API](https://www.opencost.io/docs/integrations/api#cloudcost) provides the available query parameters and the [API Examples](https://www.opencost.io/docs/integrations/api-examples#cloudcost-examples) show how you could query the Services by your Provider or how to get billing items over a range of time.
+
+### Using the OpenCost UI from Docker
+
+The OpenCost UI can be used to view Cloud Costs from Docker as well. You can pull down the image from from [ghcr.io/opencost/opencost-ui:1.109.0](https://github.com/opencost/opencost/pkgs/container/opencost-ui)
+
+`docker pull ghcr.io/opencost/opencost-ui:1.109.0` (or `latest`)
+
+and run it from Docker without Kubernetes:
+
+`docker run -p 9090:9090 -e API_SERVER=host.docker.internal -d ghcr.io/opencost/opencost-ui:1.109.0`
+
+Go to [http://localhost:9090/cloud](http://localhost:9090/cloud) to check it out. The **Cost Allocation** tab will be empty because there’s no Kubernetes data, but the **Cloud Costs** should have whatever clouds you’ve configured access.


### PR DESCRIPTION
Documents how to run OpenCost within Docker without Cost Allocations. This is a draft until 1.109.0 is verified to work from GHCR.io.

Closes https://github.com/opencost/opencost-website/issues/188