### PR TITLE
change service port name on ingress from http-ui to opencost-ui

### DIFF
--- a/docs/installation/ui.md
+++ b/docs/installation/ui.md
@@ -41,7 +41,7 @@ spec:
               service:
                 name: opencost
                 port:
-                  name: http-ui
+                  name: opencost-ui
 ```
 
 This is also supported in the [Helm chart](helm), add the following to the relevant section of your `local.yaml` and apply via Helm.


### PR DESCRIPTION
service port name is different from [previous installation step](https://www.opencost.io/docs/installation/install#install-opencost)