### PR TITLE
Update FAQ.md with missing OCI/OKE to the list of providers

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -64,6 +64,7 @@ OpenCost has core billing integrations with:
 - AWS/EKS
 - Azure/AKS
 - GCP/GKE
+- OCI/OKE
 - On-prem clusters via custom pricing sheets
 
 ### How can I contribute to OpenCost?


### PR DESCRIPTION
Add missing OCI/OKE to the list of providers.

Fix issue #305 