### PR TITLE
Correct `container path` and `cloud` in azure cloud integration

### DIFF
--- a/docs/configuration/azure.mdx
+++ b/docs/configuration/azure.mdx
@@ -299,8 +299,8 @@ The following values can be found in the Azure Portal under *Cost Management > E
 * `<STORAGE_ACCOUNT>` is the name of the Storage account where the exported Azure cost report data is being stored.
 * `<STORAGE_ACCESS_KEY>` can be found by selecting *Access Keys* from the navigation sidebar then selecting Show keys. Using either of the two keys will work.
 * `<STORAGE_CONTAINER>` is the name that you chose for the exported cost report when you set it up. This is the name of the container where the CSV cost reports are saved in your Storage account.
-* `<CONTAINER_PATH>` is an optional value which should be used if there is more than one billing report that is exported to the configured container. The path provided should have only one billing export because OpenCost will retrieve the most recent billing report for a given month found within the path.
-* `<CLOUD>` is an optional value which denotes the cloud where the storage account exists. Possible values are `public` and `gov`. The default is `public`
+* `<CONTAINER_PATH>` should be passed empty if you do not have one and used only if there is more than one billing report that is exported to the configured container. The path provided should have only one billing export because OpenCost will retrieve the most recent billing report for a given month found within the path.
+* `<CLOUD>` is the value which denotes the cloud where the storage account exists. Possible values are `public` and `gov`. The default is `public` if an empty string is provided.
 
 Set these values into the to the Azure array in the `cloud-integration.json`:
 
@@ -316,19 +316,19 @@ Set these values into the to the Azure array in the `cloud-integration.json`:
         "cloud": "<CLOUD>",
         "authorizer": {
           "accessKey": "<STORAGE_ACCESS_KEY>",
-          "account": "<ACCOUNT>",
+          "account": "<STORAGE_ACCOUNT>",
           "authorizerType": "AzureAccessKey"
         }
       },
       {
         "subscriptionID": "<SUBSCRIPTION_ID>",
-        "account": "<ACCOUNT>",
+        "account": "<STORAGE_ACCOUNT>",
         "container": "<EXPORT_CONTAINER>",
         "path": "",
         "cloud": "<CLOUD>",
         "authorizer": {
           "accessKey": "<ACCOUNT_ACCESS_KEY>",
-          "account": "<ACCOUNT>",
+          "account": "<STORAGE_ACCOUNT>",
           "authorizerType": "AzureAccessKey"
         }
       }

--- a/docs/configuration/azure.mdx
+++ b/docs/configuration/azure.mdx
@@ -299,10 +299,10 @@ The following values can be found in the Azure Portal under *Cost Management > E
 * `<STORAGE_ACCOUNT>` is the name of the Storage account where the exported Azure cost report data is being stored.
 * `<STORAGE_ACCESS_KEY>` can be found by selecting *Access Keys* from the navigation sidebar then selecting Show keys. Using either of the two keys will work.
 * `<STORAGE_CONTAINER>` is the name that you chose for the exported cost report when you set it up. This is the name of the container where the CSV cost reports are saved in your Storage account.
-* `<CONTAINER_PATH>` should be passed empty if you do not have one and used only if there is more than one billing report that is exported to the configured container. The path provided should have only one billing export because OpenCost will retrieve the most recent billing report for a given month found within the path.
+* `<CONTAINER_PATH>` should be used if there is more than one billing report that is exported to the configured container. The path provided should have only one billing export because OpenCost will retrieve the most recent billing report for a given month found within the path. If this configuration is not used, it should be set to an empty string `""`.
 * `<CLOUD>` is the value which denotes the cloud where the storage account exists. Possible values are `public` and `gov`. The default is `public` if an empty string is provided.
 
-Set these values into the to the Azure array in the `cloud-integration.json`:
+Set these values to the Azure array in the `cloud-integration.json` file:
 
 ``` json
 {


### PR DESCRIPTION
Container path and cloud in azure cloud integration are not optional and we have to pass empty string otherwise we will start getting `Error reading json: unmarshalerDecoder` errors. This PR corrects the documentation for it. The PR also corrects the naming of account to storage account.