### PR TITLE
Fix links on "install" page

### DIFF
--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -4,12 +4,12 @@ sidebar_position: 1
 # OpenCost Setup
 
 There are several supported ways of deploying OpenCost, depending on your use case and environment. Each cloud provider has different configuration requirements depending on your deployment. For full OpenCost functionality (Kubernetes Cost Allocations, Cloud Costs, and the web UI), we recommend deploying with Helm and following the instructions specific to your cloud provider:
-* [Amazon Web Services](../configuration/aws)
-* [Microsoft Azure](../configuration/azure)
-* [Google Cloud Platform](../configuration/gcp)
-* [Oracle Cloud Infrastructure](../configuration/oracle)
-* [On-premises deployments](../configuration/on-prem)
-* [Docker (no Kubernetes support)](docker)
+* [Amazon Web Services](/configuration/aws)
+* [Microsoft Azure](/configuration/azure)
+* [Google Cloud Platform](/configuration/gcp)
+* [Oracle Cloud Infrastructure](/configuration/oracle)
+* [On-premises deployments](/configuration/on-prem)
+* [Docker (no Kubernetes support)](/installation/docker)
 
 ## Requirements
 
@@ -32,10 +32,10 @@ To verify that the server is running, access [http://localhost:9003/allocation/c
 ### Accessing OpenCost Data
 
 Beyond the OpenCost UI, you may access the cost monitoring data for OpenCost through:
-* [OpenCost API](../integrations/api) and [API examples](../integrations/api-examples)
-* [kubectl cost](../integrations/kubectl-cost) plugin
-* [CSV Exports](../integrations/csv-export)
-* [Parquet Exports](../integrations/parquet-export)
+* [OpenCost API](/integrations/api) and [API examples](/integrations/api-examples)
+* [kubectl cost](/integrations/kubectl-cost) plugin
+* [CSV Exports](/integrations/csv-export)
+* [Parquet Exports](/integrations/parquet-export)
 
 ## Updating OpenCost
 


### PR DESCRIPTION
Clicking links on the "install" page led to the following errors:

![Screenshot 2025-03-10 at 10 48 07 AM](https://github.com/user-attachments/assets/683e8b29-9eb3-4f81-b324-90be0a63c71e)

Try fixing the issue by absolute paths for links, instead of relative paths. https://docusaurus.io/docs/markdown-features/links