### PR TITLE
Update install.mdx

### DIFF
--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -4,11 +4,11 @@ sidebar_position: 1
 # OpenCost Setup
 
 There are several supported ways of deploying OpenCost, depending on your use case and environment. Each cloud provider has different configuration requirements depending on your deployment. For full OpenCost functionality (Kubernetes Cost Allocations, Cloud Costs, and the web UI), we recommend deploying with Helm and following the instructions specific to your cloud provider:
-* [Amazon Web Services](../configuration/aws)
-* [Microsoft Azure](../configuration/azure)
-* [Google Cloud Platform](../configuration/gcp)
-* [Oracle Cloud Infrastructure](../configuration/oracle)
-* [On-premises deployments](../configuration/on-prem)
+* [Amazon Web Services](../../configuration/aws)
+* [Microsoft Azure](../../configuration/azure)
+* [Google Cloud Platform](../../configuration/gcp)
+* [Oracle Cloud Infrastructure](../../configuration/oracle)
+* [On-premises deployments](../../configuration/on-prem)
 * [Docker (no Kubernetes support)](docker)
 
 ## Requirements


### PR DESCRIPTION
Fix links to cloud providers pages

The links on https://opencost.io/docs/installation/install/ to the cloud providers pages require a further directory up in the link

eg

https://opencost.io/docs/installation/install/
to
https://opencost.io/docs/configuration/aws/

```
[Amazon Web Services](../../configuration/aws)
```