### PR TITLE
added-mcp-docs

### DIFF
--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -34,6 +34,7 @@ To verify that the server is running, access [http://localhost:9003/allocation/c
 Beyond the OpenCost UI, you may access the cost monitoring data for OpenCost through:
 * [OpenCost API](../integrations/api) and [API examples](../integrations/api-examples)
 * [kubectl cost](../integrations/kubectl-cost) plugin
+* [MCP Server](../integrations/mcp) for AI agents and automation
 * [CSV Exports](../integrations/csv-export)
 * [Parquet Exports](../integrations/parquet-export)
 

--- a/docs/integrations/integrations.md
+++ b/docs/integrations/integrations.md
@@ -23,6 +23,9 @@ OpenCost may be integrated with a wide variety of technologies. Below is a list 
 * [Grafana](https://grafana.com/orgs/kubecost)
 * [Grafana Cloud](https://grafana.com/blog/2023/06/26/rein-in-spending-with-kubernetes-cost-monitoring-in-grafana-cloud/)
 
+## AI and Automation
+* [MCP Server](./mcp) - Model Context Protocol server for AI agents
+
 ## Miscellaneous
 * [Prometheus OpenCost Exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-opencost-exporter)
 * [Kubefirst](https://kubefirst.io/blog/release2-2/)

--- a/docs/integrations/mcp.md
+++ b/docs/integrations/mcp.md
@@ -1,0 +1,216 @@
+---
+title: MCP Server
+sidebar_position: 9
+description: OpenCost MCP (Model Context Protocol) server provides AI agents with access to cost allocation and asset data through a standardized interface.
+---
+
+# MCP Server
+
+The OpenCost MCP (Model Context Protocol) server provides AI agents with access to cost allocation and asset data through a standardized interface. The MCP server is **enabled by default** in all OpenCost deployments, runs on port 8081, and is **built into the Helm chart** for easy production deployment. Users have full control to disable it or configure custom ports and settings.
+
+## Features
+
+- **Enabled by Default**: MCP server starts automatically with OpenCost
+- **Full User Control**: Easy to disable or configure port and settings
+- **Allocation Queries**: Retrieve cost allocation data with filtering and aggregation
+- **Asset Queries**: Access detailed asset information including nodes, disks, load balancers, and more
+- **Cloud Cost Queries**: Query cloud cost data with provider, service, and region filtering
+- **HTTP Transport**: Uses HTTP for reliable communication with MCP clients
+- **Zero Configuration**: Works out of the box with default OpenCost deployment
+- **Helm Integration**: Built into the official Helm chart for production deployments
+
+## Quick Start
+
+### Using Tilt (Development)
+
+```bash
+# Clone and start OpenCost with MCP server
+git clone https://github.com/opencost/opencost.git
+cd opencost
+tilt up
+```
+
+Tilt configuration notes (cloud costs):
+
+OpenCost's Tilt values (`tilt-values.yaml`) include extra environment variables to enable Cloud Cost ingestion in dev:
+
+```yaml
+# tilt-values.yaml (excerpt)
+opencost:
+  exporter:
+    extraEnv:
+      CLOUD_COST_ENABLED: "true"
+      CLOUD_COST_CONFIG_PATH: "/var/cloud-integration/cloud-integration.json"
+```
+
+- Set `CLOUD_COST_ENABLED` to "true" to turn on cloud cost ingestion.
+- Point `CLOUD_COST_CONFIG_PATH` to the mounted cloud integration file used by Tilt (e.g., `/var/cloud-integration/cloud-integration.json`).
+- Adjust other values in `tilt-values.yaml` as needed during development.
+
+### Using Helm (Production)
+
+```bash
+# Add the OpenCost Helm repository
+helm repo add opencost https://opencost.github.io/opencost-helm-chart
+helm repo update
+
+# Deploy OpenCost with MCP server (enabled by default)
+helm install opencost opencost/opencost
+
+# Access MCP server via port forwarding (example)
+kubectl port-forward svc/opencost 8081:8081
+```
+
+The MCP server is **enabled by default** in the Helm chart. For custom configuration:
+
+```bash
+# Deploy with MCP server disabled
+helm install opencost opencost/opencost \
+  --set opencost.mcp.enabled=false
+
+# Deploy with custom MCP port
+helm install opencost opencost/opencost \
+  --set opencost.mcp.port=9091
+
+# Deploy with debug logging
+helm install opencost opencost/opencost \
+  --set opencost.mcp.extraEnv.MCP_LOG_LEVEL=debug
+```
+
+### Configuration Summary
+
+| Configuration | Command | Description |
+|---------------|---------|-------------|
+| **Default** | `helm install opencost opencost/opencost` | MCP enabled on port 8081 |
+| **Disable** | `--set opencost.mcp.enabled=false` | Completely disable MCP server |
+| **Custom Port** | `--set opencost.mcp.port=9091` | Use different port |
+| **Debug Mode** | `--set opencost.mcp.extraEnv.MCP_LOG_LEVEL=debug` | Enable debug logging |
+
+## MCP Client Configuration
+
+Configure your MCP client (e.g., Cursor) to connect to the OpenCost MCP server:
+
+### Default configuration (port 8081)
+
+```json
+{
+  "mcpServers": {
+    "opencost": {
+      "type": "http",
+      "url": "http://localhost:8081"
+    }
+  }
+}
+```
+
+### Custom port configuration
+
+```json
+{
+  "mcpServers": {
+    "opencost": {
+      "type": "http",
+      "url": "http://localhost:9091"
+    }
+  }
+}
+```
+
+### For Kubernetes deployments
+
+```json
+{
+  "mcpServers": {
+    "opencost": {
+      "type": "http",
+      "url": "http://opencost.opencost.svc.cluster.local:8081"
+    }
+  }
+}
+```
+
+### For external access (with LoadBalancer/Ingress)
+
+```json
+{
+  "mcpServers": {
+    "opencost": {
+      "type": "http",
+      "url": "http://your-opencost-domain.com:8081"
+    }
+  }
+}
+```
+
+## Available MCP Tools
+
+The MCP server provides these tools for AI agents:
+
+### `get_allocation_costs`
+
+Retrieve cost allocation data with filtering and aggregation.
+
+**Parameters:**
+- `window` (required): Time window (e.g., "7d", "1h", "30m")
+- `aggregate` (optional): Aggregation properties (e.g., "namespace", "pod", "node")
+- `step` (optional): Resolution step size
+- `accumulate` (optional): Whether to accumulate over time
+- `share_idle` (optional): Whether to share idle costs
+- `include_idle` (optional): Whether to include idle resources
+
+### `get_asset_costs`
+
+Retrieve asset cost data including nodes, disks, load balancers, and more.
+
+**Parameters:**
+- `window` (required): Time window (e.g., "7d", "1h", "30m")
+
+### `get_cloud_costs`
+
+Retrieve cloud cost data with provider, service, and region filtering.
+
+**Parameters:**
+- `window` (required): Time window (e.g., "7d", "1h", "30m")
+- `aggregate` (optional): Aggregation properties (e.g., "provider", "service", "region")
+- `accumulate` (optional): Time accumulation ("day", "week", "month")
+- `provider` (optional): Filter by cloud provider (e.g., "aws", "gcp", "azure")
+- `service` (optional): Filter by service (e.g., "ec2", "compute", "s3")
+- `category` (optional): Filter by category (e.g., "compute", "storage", "network")
+- `region` (optional): Filter by region (e.g., "us-west-1", "us-central1")
+- `accountID` (optional): Filter by account ID
+
+## Supported Asset Types
+
+- **Node**: Compute instances with CPU, RAM, GPU details
+- **Disk**: Storage volumes with usage and cost breakdown
+- **LoadBalancer**: Load balancer instances with IP and private status
+- **Network**: Network-related costs and usage
+- **Cloud**: Cloud service costs with credit information
+- **ClusterManagement**: Kubernetes cluster management costs
+
+## Example Usage
+
+Once configured, AI agents can query cost data like:
+
+```javascript
+// Get cost allocation for the last 7 days
+const allocation = await mcpClient.callTool('get_allocation_costs', {
+  window: '7d',
+  aggregate: 'namespace,node'
+});
+
+// Get asset costs for the last 24 hours
+const assets = await mcpClient.callTool('get_asset_costs', {
+  window: '1d'
+});
+
+// Get cloud costs for AWS EC2 in us-west-1
+const cloudCosts = await mcpClient.callTool('get_cloud_costs', {
+  window: '7d',
+  aggregate: 'service',
+  provider: 'aws',
+  service: 'ec2',
+  accumulate: 'day',
+  filter: 'regionID:"us-west-1"'
+});
+```


### PR DESCRIPTION
# Add MCP Server Documentation to OpenCost Website

## Summary
This PR adds comprehensive documentation for the OpenCost MCP (Model Context Protocol) server to the official OpenCost website. The MCP server enables AI agents to access cost allocation and asset data through a standardized interface.

## Changes Made

### New Documentation
- **`docs/integrations/mcp.md`** - Complete MCP server documentation including:
  - Features and overview
  - Quick start guide for both Tilt (development) and Helm (production)
  - Configuration options (enable/disable, custom ports, debug mode)
  - MCP client configuration examples for different deployment scenarios
  - Detailed documentation of all three MCP tools:
    - `get_allocation_costs` - Cost allocation data with filtering and aggregation
    - `get_asset_costs` - Asset information (nodes, disks, load balancers)
    - `get_cloud_costs` - Cloud cost data with provider, service, and region filtering
  - Supported asset types
  - JavaScript code examples