### PR TITLE
docs: replaced individual cloud options with link to cloud service provider config

### DIFF
--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -4,10 +4,7 @@ sidebar_position: 1
 # OpenCost Setup
 
 There are several supported ways of deploying OpenCost, depending on your use case and environment. Each cloud provider has different configuration requirements depending on your deployment. For full OpenCost functionality (Kubernetes Cost Allocations, Cloud Costs, and the web UI), we recommend deploying with Helm and following the instructions specific to your cloud provider:
-* [Amazon Web Services](../configuration/aws)
-* [Microsoft Azure](../configuration/azure)
-* [Google Cloud Platform](../configuration/gcp)
-* [Oracle Cloud Infrastructure](../configuration/oracle)
+* [Cloud service provider configuration](https://opencost.io/docs/configuration/)
 * [On-premises deployments](../configuration/on-prem)
 * [Docker (no Kubernetes support)](docker)
 


### PR DESCRIPTION
Replaced individual cloud options with a link to the cloud service provider configuration per issue #409