### PR TITLE
docs: add OVHcloud provider configuration page

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -13,6 +13,7 @@ Accessing cloud service provider billing and pricing APIs may require additional
 * [Microsoft Azure](azure.mdx)
 * [Open Telekom Cloud](otc.mdx)
 * [Oracle Cloud Infrastructure](oracle.mdx)
+* [OVHcloud](ovh.mdx)
 * Scaleway \(documentation needed\)
 
 ## Cloud Costs
@@ -49,7 +50,7 @@ Please note that the cloud costs become available as soon as they appear in the 
 
 In some cases users may need to override the pricing provided by their cloud service provider. They may have negotiated with their cloud service provider or may be acting as an intermediary with their own rates that do not follow list prices.
 
-If this is the case, you may provide overrides in your local OpenCost Helm values file to match the name of the cloud provider you are overriding. The current options are `alibaba`, `aws`, `azure`, `gcp`, `oracle`, or `default` for on-premises pricing. This example overrides GCP pricing:
+If this is the case, you may provide overrides in your local OpenCost Helm values file to match the name of the cloud provider you are overriding. The current options are `alibaba`, `aws`, `azure`, `gcp`, `oracle`, `ovh`, or `default` for on-premises pricing. This example overrides GCP pricing:
 
 ```yaml
 opencost:

--- a/docs/configuration/ovh.mdx
+++ b/docs/configuration/ovh.mdx
@@ -1,0 +1,152 @@
+---
+sidebar_position: 7
+title: OVHcloud
+---
+import CustomPrometheus from './_custom_prometheus.mdx';
+import Helm from './_helm.mdx';
+import InstallManifest from './_install_manifest.mdx';
+import InstallOpenCost from './_install_opencost.mdx';
+import InstallPrometheus from './_install_prometheus.mdx';
+import Installing from './_installing.mdx';
+import Namespace from './_namespace.mdx';
+import UpdateOpenCost from './_update_opencost.mdx';
+
+# Installing on OVHcloud
+
+OpenCost may be installed on Kubernetes clusters running on OVHcloud, including Managed Kubernetes Service (MKS) clusters.
+<Installing/>
+
+:::info
+
+OVHcloud support is available starting from the next release after 1.119.2. If you need it before the official release, you may use the `develop-latest` image tag.
+
+:::
+
+## Install Prometheus
+
+<InstallPrometheus/>
+<CustomPrometheus/>
+
+:::tip
+
+If you are using kube-prometheus-stack (Prometheus Operator), you can skip the `extraScrapeConfigs` and enable the ServiceMonitor in the OpenCost Helm chart instead:
+
+```yaml
+opencost:
+  metrics:
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: <your-prometheus-stack-release-name>
+```
+
+:::
+
+## Create the OpenCost Namespace
+
+<Namespace/>
+
+## OVHcloud Configuration
+
+### Cost Allocation
+
+OpenCost will automatically detect OVHcloud as the cloud service provider (CSP) by reading node labels. When the label `node.k8s.ovh/type` is present, OpenCost identifies the cluster as running on OVHcloud.
+
+Once detected, OpenCost retrieves real-time pricing data from the [OVH Public Cloud Catalog API](https://eu.api.ovh.com/v1/order/catalog/public/cloud?ovhSubsidiary=FR). This includes:
+
+- **Instance pricing**: hourly and monthly rates for all Public Cloud flavors (general purpose, CPU, RAM, GPU, discovery, IOPS)
+- **Volume pricing**: per-GB/hour rates for all Cinder volume types (classic, high-speed, high-speed-gen2)
+
+No API key is required to retrieve the public pricing data.
+
+#### Environment Variables
+
+The following optional environment variables may be used to customize OVHcloud pricing behavior:
+
+| Variable                 | Default | Description                                                                                                        |
+|--------------------------|---------|--------------------------------------------------------------------------------------------------------------------|
+| `OVH_SUBSIDIARY`         | `FR`    | OVH subsidiary for catalog pricing (e.g., `FR`, `DE`, `US`, `GB`). Determines the currency and regional pricing. |
+| `OVH_MONTHLY_NODEPOOLS`  | (empty) | Comma-separated list of nodepool names that use monthly billing instead of hourly consumption pricing.             |
+| `REGION_OVERRIDE_LIST`   | (empty) | Comma-separated list of OVH regions to query. Overrides the built-in region list if set.                          |
+
+#### Monthly vs. Hourly Pricing
+
+OVHcloud offers both hourly (consumption) and monthly billing for Public Cloud instances. By default, OpenCost uses hourly pricing for all nodes. If some of your nodepools use monthly billing, set the `OVH_MONTHLY_NODEPOOLS` environment variable:
+
+```yaml
+opencost:
+  exporter:
+    extraEnv:
+      OVH_MONTHLY_NODEPOOLS: "my-monthly-pool,another-monthly-pool"
+```
+
+Monthly prices are converted to an equivalent hourly rate (monthly price / 730 hours) for consistent cost allocation.
+
+Alternatively, you can override billing mode per node using the `ovh.opencost.io/billing` label with a value of `monthly` or `hourly`:
+
+```sh
+kubectl label node <node-name> ovh.opencost.io/billing=monthly
+```
+
+This label takes precedence over the `OVH_MONTHLY_NODEPOOLS` environment variable for the labeled node.
+
+#### Persistent Volume Pricing
+
+OpenCost automatically prices Persistent Volumes backed by OVHcloud Cinder CSI. The volume type is resolved from:
+
+1. A built-in mapping of StorageClass names to OVH volume types
+2. The `type` parameter in the StorageClass specification (fallback)
+
+Supported volume types include `classic`, `high-speed`, and `high-speed-gen2` (plus their `-luks` encrypted variants).
+
+### Custom Pricing
+
+If you need to override the default OVHcloud pricing retrieved from the catalog API, you may provide custom pricing in your Helm values:
+
+```yaml
+opencost:
+  customPricing:
+    enabled: true
+    provider: ovh
+    costModel:
+      description: Custom OVH pricing overrides
+      CPU: "0.03405"
+      RAM: "0.009729"
+      GPU: "1.80"
+      storage: "0.000119"
+```
+
+## OVHcloud Cloud Costs
+
+:::note
+
+Cloud Costs are not currently supported for OVHcloud. Support is planned for a future release.
+
+:::
+
+## Install OpenCost
+
+<Helm/>
+
+### Using the OpenCost Helm Chart
+
+<InstallOpenCost/>
+
+To enable the OVHcloud provider explicitly (e.g., when running outside an MKS cluster), set the `CLOUD_PROVIDER` environment variable:
+
+```yaml
+opencost:
+  exporter:
+    extraEnv:
+      CLOUD_PROVIDER: "OVH"
+```
+
+### Updating OpenCost via Helm
+
+<UpdateOpenCost/>
+
+### Installing with the OpenCost Manifest
+
+Installing from the OpenCost manifest is supported on OVHcloud.
+
+<InstallManifest/>

--- a/docs/integrations/integrations.md
+++ b/docs/integrations/integrations.md
@@ -10,6 +10,7 @@ OpenCost may be integrated with a wide variety of technologies. Below is a list 
 * [AWS](../configuration/aws.mdx)
 * [GCP](../configuration/gcp.mdx)
 * [Oracle Cloud Infrastructure](../configuration/oracle.mdx)
+* [OVHcloud](../configuration/ovh.mdx)
 * [Alibaba](https://alibabacloud.com/)
 * [Scaleway](https://www.scaleway.com/en/)
 


### PR DESCRIPTION
## Summary

- Add OVHcloud configuration documentation page (`docs/configuration/ovh.mdx`)
- Add OVHcloud to the provider list and custom pricing options in `configuration.md`

## Details

Covers:
- Auto-detection via `node.k8s.ovh/type` label
- Public Cloud Catalog API pricing (no API key required)
- Environment variables (`OVH_SUBSIDIARY`, `OVH_MONTHLY_NODEPOOLS`, `REGION_OVERRIDE_LIST`)
- Monthly vs. hourly billing (nodepool env var + per-node label)
- Persistent Volume pricing via Cinder CSI
- Custom pricing overrides
- ServiceMonitor tip for kube-prometheus-stack users
- Cloud Costs placeholder (not yet supported)

## Related

- Provider PR: https://github.com/opencost/opencost/pull/3627
- OVH roadmap: https://github.com/ovh/public-cloud-roadmap/issues/875
- OpenCost issue: https://github.com/opencost/opencost/issues/2779