### PR TITLE
📖 Add guided install reference for KubeStellar Console

### DIFF
--- a/docs/installation/guided-install.md
+++ b/docs/installation/guided-install.md
@@ -21,6 +21,7 @@ title: Guided Install with KubeStellar Console
 2. Connect your kubeconfig context
 3. Follow the step-by-step instructions
 
+> **Security note:** Before connecting a kubeconfig context to a browser-based third-party tool, verify the tool and source you are using, prefer least-privilege credentials or a dedicated context, avoid production clusters when possible, and understand what cluster data, command output, or credentials metadata may be transmitted to or stored by the service.
 The mission definition is open source and available on GitHub:
 [install-opencost.json](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-opencost.json)
 

--- a/docs/installation/guided-install.md
+++ b/docs/installation/guided-install.md
@@ -1,0 +1,35 @@
+---
+sidebar_position: 7
+title: Guided Install with KubeStellar Console
+---
+
+# Guided Install with KubeStellar Console
+
+[KubeStellar Console](https://console.kubestellar.io) offers a browser-based guided installation experience for OpenCost. The guided install mission walks through each step interactively, running commands against your cluster via your kubeconfig context.
+
+## What the guided install provides
+
+- **Pre-flight checks** — verifies cluster connectivity, Helm availability, and prerequisites before starting
+- **Step-by-step commands** — each installation step is presented individually with explanations
+- **Cluster validation** — confirms that OpenCost pods are running and healthy after installation
+- **Troubleshooting** — surfaces common issues and suggests fixes if a step fails
+- **Rollback support** — provides commands to cleanly uninstall if needed
+
+## Getting started
+
+1. Visit the [OpenCost guided install mission](https://console.kubestellar.io/missions/install-opencost)
+2. Connect your kubeconfig context
+3. Follow the step-by-step instructions
+
+The mission definition is open source and available on GitHub:
+[install-opencost.json](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-opencost.json)
+
+## When to use the guided install
+
+The guided install is a good fit if you:
+
+- Are new to OpenCost and want a walkthrough of the installation process
+- Want automated pre-flight validation before installing
+- Prefer an interactive experience over running Helm commands manually
+
+For full control over configuration options, see the [Helm installation guide](helm).

--- a/docs/installation/guided-install.md
+++ b/docs/installation/guided-install.md
@@ -22,7 +22,7 @@ title: Guided Install with KubeStellar Console
 3. Follow the step-by-step instructions
 
 The mission definition is open source and available on GitHub:
-[install-opencost.json](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-opencost.json)
+[install-opencost.json](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-opencost.json)
 
 ## When to use the guided install
 

--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -7,6 +7,13 @@ There are several supported ways of deploying OpenCost, depending on your use ca
 * [Cloud service provider configuration](/docs/configuration)
 * [On-premises deployments](/docs/configuration/on-prem)
 * [Docker (no Kubernetes support)](/docs/installation/docker)
+
+For supported troubleshooting and the full set of configuration options, use [Helm](/docs/installation/helm).
+
+### Community-maintained installers
+
+These are third-party tools maintained by the community, not officially supported by the OpenCost project. They wrap one of the supported install paths above and are offered as a convenience for users who prefer a guided experience. For any support or troubleshooting questions, please use the official Helm path.
+
 * [Guided install with KubeStellar Console](/docs/installation/guided-install)
 
 ## Requirements

--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -7,6 +7,7 @@ There are several supported ways of deploying OpenCost, depending on your use ca
 * [Cloud service provider configuration](/docs/configuration)
 * [On-premises deployments](/docs/configuration/on-prem)
 * [Docker (no Kubernetes support)](/docs/installation/docker)
+* [Guided install with KubeStellar Console](/docs/installation/guided-install) — interactive step-by-step installation with pre-flight checks and validation
 
 ## Requirements
 

--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -7,7 +7,7 @@ There are several supported ways of deploying OpenCost, depending on your use ca
 * [Cloud service provider configuration](/docs/configuration)
 * [On-premises deployments](/docs/configuration/on-prem)
 * [Docker (no Kubernetes support)](/docs/installation/docker)
-* [Guided install with KubeStellar Console](/docs/installation/guided-install) — interactive step-by-step installation with pre-flight checks and validation
+* [Guided install with KubeStellar Console](/docs/installation/guided-install)
 
 ## Requirements
 

--- a/docs/integrations/integrations.md
+++ b/docs/integrations/integrations.md
@@ -28,7 +28,7 @@ OpenCost may be integrated with a wide variety of technologies. Below is a list 
 * [MCP Server](./mcp) - Model Context Protocol server for AI agents
 
 ## Community Tools
-* [KubeStellar Console Guided Install](https://console.kubestellar.io/missions/install-opencost) - Interactive guided installation with pre-flight checks, validation, and rollback
+* [KubeStellar Console Guided Install](https://console.kubestellar.io/missions/install-opencost) - Community-maintained third-party guided installation for OpenCost with pre-flight checks, validation, and rollback; not an official OpenCost integration
 
 ## Miscellaneous
 * [Prometheus OpenCost Exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-opencost-exporter)

--- a/docs/integrations/integrations.md
+++ b/docs/integrations/integrations.md
@@ -26,6 +26,9 @@ OpenCost may be integrated with a wide variety of technologies. Below is a list 
 ## AI and Automation
 * [MCP Server](./mcp) - Model Context Protocol server for AI agents
 
+## Community Tools
+* [KubeStellar Console Guided Install](https://console.kubestellar.io/missions/install-opencost) - Interactive guided installation with pre-flight checks, validation, and rollback
+
 ## Miscellaneous
 * [Prometheus OpenCost Exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-opencost-exporter)
 * [Kubefirst](https://kubefirst.io/blog/release2-2/)


### PR DESCRIPTION
## Summary

Adds documentation for the [KubeStellar Console](https://console.kubestellar.io) guided install mission for OpenCost, as suggested in opencost/opencost#3649.

The guided install provides an interactive, browser-based installation experience with pre-flight checks, step-by-step commands, cluster validation, troubleshooting, and rollback support — all running against the user's live cluster via kubeconfig.

**Changes:**
- New page `docs/installation/guided-install.md` describing the guided install experience
- Reference added to the main installation page (`install.mdx`) alongside existing deployment options
- Entry added to the integrations page under a new "Community Tools" section

**Links:**
- Guided install mission: https://console.kubestellar.io/missions/install-opencost
- Mission definition (open source): https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-opencost.json
- Context: opencost/opencost#3649