### PR TITLE
Fix broken manifest link and update install docs to use Helm

### DIFF
--- a/docs/configuration/_install_manifest.mdx
+++ b/docs/configuration/_install_manifest.mdx
@@ -1,5 +1,7 @@
-For basic Kubernetes Cost Allocations _without_ Cloud Costs or any customizations you may use the OpenCost manifest. Prometheus is still required and the Helm chart installation is recommended for anything beyond this simple use case.
+OpenCost standalone Kubernetes manifest installation is no longer supported. Use the OpenCost Helm chart for installation and upgrades:
 
 ```sh
-kubectl apply --namespace opencost -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/opencost.yaml
+helm repo add opencost https://opencost.github.io/opencost-helm-chart
+helm repo update
+helm install opencost opencost/opencost --namespace opencost --create-namespace
 ```

--- a/docs/configuration/on-prem.mdx
+++ b/docs/configuration/on-prem.mdx
@@ -87,6 +87,6 @@ The values in the example above will be reflected in the OpenCost with substanti
 
 ### Installing with the OpenCost Manifest
 
-Installing from the OpenCost manifest is supported for on-prem.
+OpenCost manifest-based installation has been replaced by the Helm chart installation flow.
 
 <InstallManifest/>

--- a/docs/configuration/on-prem.mdx
+++ b/docs/configuration/on-prem.mdx
@@ -5,7 +5,6 @@ title: On-Premises
 import CloudCosts from './_cloud_costs.mdx';
 import CustomPrometheus from './_custom_prometheus.mdx';
 import Helm from './_helm.mdx';
-import InstallManifest from './_install_manifest.mdx';
 import InstallOpenCost from './_install_opencost.mdx';
 import InstallPrometheus from './_install_prometheus.mdx';
 import Installing from './_installing.mdx';
@@ -84,9 +83,3 @@ The values in the example above will be reflected in the OpenCost with substanti
 ### Updating OpenCost via Helm
 
 <UpdateOpenCost/>
-
-### Installing with the OpenCost Manifest
-
-OpenCost manifest-based installation has been replaced by the Helm chart installation flow.
-
-<InstallManifest/>

--- a/docs/installation/install.mdx
+++ b/docs/installation/install.mdx
@@ -60,9 +60,7 @@ $ helm uninstall prometheus
 $ kubectl delete namespace prometheus-system
 ```
 
-If you installed with the manifest, enter the following command:
-
-`kubectl delete -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/opencost.yaml`
+If you previously installed using an older standalone manifest, uninstall those resources based on the manifest content you originally applied. New installations should use Helm.
 
 ## Help
 


### PR DESCRIPTION
Fixes #438

## Summary

The installation docs were pointing to a raw `opencost.yaml` manifest that now returns a 404.

After checking the opencost repository, standalone Kubernetes manifests are no longer available and Helm is the recommended way to install OpenCost.

## What I changed

* Removed the broken manifest URL from the docs
* Updated installation instructions to use Helm instead
* Added a small note to clarify that manifest-based installation is no longer supported

## Notes

I kept this change focused only on installation/configuration docs. I noticed a few older blog posts still reference the old manifest, but didn’t update those to keep this PR scoped.

Happy to update those as well if needed.