### PR TITLE
Update YT link to new CNCF site

### DIFF
--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -56,7 +56,7 @@ export default function Community() {
                   <a href="https://www.linkedin.com/showcase/opencost/" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">LinkedIn</a>
                   <a href="https://hachyderm.io/@opencost" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">Mastodon</a>
                   <a href="https://twitter.com/open_cost" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">Twitter</a>
-                  <a href="https://www.youtube.com/@OpenCost" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">YouTube</a>
+                  <a href="https://www.youtube.com/@CNCFOpenCost" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">YouTube</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Simple update to the community site to repoint the YT link. 