### PR TITLE
Remove Bluesky, Mastodon, and Twitter from community social links

### DIFF
--- a/src/pages/community/index.js
+++ b/src/pages/community/index.js
@@ -52,10 +52,7 @@ export default function Community() {
 
                 <h2>Social Media</h2>
                 <div className={styles.socialLinks}>
-                  <a href="https://bsky.app/profile/opencost.bsky.social" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">Bluesky</a>
                   <a href="https://www.linkedin.com/showcase/opencost/" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">LinkedIn</a>
-                  <a href="https://hachyderm.io/@opencost" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">Mastodon</a>
-                  <a href="https://twitter.com/open_cost" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">Twitter</a>
                   <a href="https://www.youtube.com/@CNCFOpenCost" target="_blank" rel="noopener noreferrer" className="button button--outline button--primary">YouTube</a>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
This PR removes three social media platform links from the Community page, keeping only LinkedIn and YouTube as the primary social channels for OpenCost.

## Changes
- Removed Bluesky social media link
- Removed Mastodon social media link
- Removed Twitter social media link
- Retained LinkedIn and YouTube links as active social channels

## Details
The social media section on the community page has been streamlined to focus on LinkedIn and YouTube as the primary platforms for community engagement and updates.