### PR TITLE
Remove Check Links badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Check Links](https://github.com/org/repo/actions/workflows/links.yml/badge.svg)](https://github.com/org/repo/actions/workflows/links.yml)
-
 # OpenCost Website
 
 This repository hosts the [OpenCost website](https://opencost.io), documentation, and blog.


### PR DESCRIPTION
## Summary
Removed the Check Links workflow badge from the top of the README.md file.

## Changes
- Removed the Check Links GitHub Actions badge and associated blank line from the README header

## Details
This change simplifies the README by removing the workflow status badge. The badge was linking to the `links.yml` workflow in the GitHub Actions section.

Fixes - https://github.com/opencost/opencost-website/issues/496