### PR TITLE
docs: clarify setup paths on overview page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,14 @@ slug: /
 
 OpenCost is a vendor-neutral open source project for measuring and allocating cloud infrastructure and container costs. It’s built for Kubernetes cost monitoring to power real-time cost monitoring, showback, and chargeback.
 
+## Choose your setup path
+
+Select the guidance that best matches your environment:
+
+* For cloud-provider billing integration, see [Integrating Cloud Costs and Configuration](#integrating-cloud-costs-and-configuration).
+* For on-premises environments, see [On-Premises](#on-premises).
+* To run OpenCost outside Kubernetes, see the [Docker installation guide](./installation/docker).
+
 Below are common documentation pages for the OpenCost Project:
 
 ## Installation


### PR DESCRIPTION
## Summary

Adds a short “Choose your setup path” section to the OpenCost documentation overview page.

## Why

The overview page currently lists several documentation resources but does not immediately distinguish the main setup paths. This update helps users quickly navigate to guidance for:

* Cloud-provider billing integration
* On-premises environments
* Running OpenCost outside Kubernetes using Docker

## Changes

* Added a concise setup-path navigation section
* Linked to the existing cloud-cost and on-premises sections
* Linked to the existing Docker installation guide

Fixes #411